### PR TITLE
Fix crashing after switching to Favorites tab

### DIFF
--- a/Podcasts/Modules/View Controllers/Favorites/FavoritesViewController.swift
+++ b/Podcasts/Modules/View Controllers/Favorites/FavoritesViewController.swift
@@ -18,7 +18,8 @@ final class FavoritesViewController: UICollectionViewController {
          collectionViewLayout: UICollectionViewLayout = UICollectionViewFlowLayout()) {
         // FIXME: - Crash due to collection view layout is nil
         self.viewModel = viewModel
-        super.init(nibName: nil, bundle: nil)
+        super.init(collectionViewLayout: collectionViewLayout)
+        
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
Hello
Application Crashing on the Tap of Favourites Tab is Fixed.
There is only one change in FavouritesViewController in line 21.
In Order to instantiate the custom  UICollectionViewController , the superclass initializer with UICollectionViewLayout needs to be called.
Thanks